### PR TITLE
fix: Set src folder as a local package

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ source venv/bin/activate
 
 ```
 python -m venv venv
-.\env\Scripts\activate
+.\venv\Scripts\activate
 ```
 
 If you use *pyenv* or *pyenv-win*, you can run this command to set the python version: `pyenv local 3.9.X`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ First clone the git repository to your local machine.
 
 `git clone https://github.com/dataforgoodfr/shiftdataportal_data.git`
 
-Then you need to create a virtual environment in the repository you've just cloned and install the required packages.
+Then you need to create a virtual environment in the repository you have just cloned and install the required packages.
 
 ```
 cd shiftdataportal_data
@@ -42,6 +42,7 @@ python3 -m venv venv
 source venv/bin/activate
 pip install -U pip
 pip install -r requirements.txt
+pip install -e .
 ```
 
 After this, you should be ready to contribute!

--- a/README.md
+++ b/README.md
@@ -26,20 +26,36 @@ Each raw_{source}.py define configuration/implementation of the Api and/or File 
 
 ## Contributing
 
-The next steps will use the Linux command lines. The documentation for Windows system will be added later, meanwhile, 
-you can have a look at this [documentation](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/)
-to create your virtual environment and install the packages.
+We use Python 3.9, ensure you have this version on your computer. If you already have another version, you can manage several versions of Python with [pyenv](https://github.com/pyenv/pyenv) for Linux/MacOS or [pyenv-win](https://github.com/pyenv-win/pyenv-win) for Windows.
 
-First clone the git repository to your local machine.
-
-`git clone https://github.com/dataforgoodfr/shiftdataportal_data.git`
-
-Then you need to create a virtual environment in the repository you have just cloned and install the required packages.
+First clone the git repository to your local machine and go inside the project folder.
 
 ```
+git clone https://github.com/dataforgoodfr/shiftdataportal_data.git
 cd shiftdataportal_data
+```
+
+Then you can create the virtual environment and activate it.
+
+- On Linux/MacOS
+
+```
 python3 -m venv venv
 source venv/bin/activate
+```
+
+- On Windows
+
+```
+python -m venv venv
+.\env\Scripts\activate
+```
+
+If you use *pyenv* or *pyenv-win*, you can run this command to set the python version: `pyenv local 3.9.X`.
+
+And finally you can install all the packages needed, first *pip*, then the external packages and the local ones.
+
+```
 pip install -U pip
 pip install -r requirements.txt
 pip install -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[metadata]
+name = sdp-data-lib
+version = 0.1.0
+
+[options]
+packages = src

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+import setuptools
+
+setuptools.setup()


### PR DESCRIPTION
Ces fichiers permettent de faire savoir à Python que le répertoire `src` est un package local, ce qui permettra d'importer les modules et packages locaux plus facilement dans le code. Il faut l'installer au préalable avec la commande `pip install -e .`